### PR TITLE
ignore empty locator

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -95,12 +95,14 @@ export class Util {
     }
 
     static getFilesFromTestLocators(locators: Set<string>): Set<string> {
-    const files = new Set<string>();
-       for (const locator of locators) {
-           const file = path.resolve(locator.split(LocatorSeparator)[0])
-           files.add(file)
-       }
-       return files
+        const files = new Set<string>();
+        for (const locator of locators) {
+            if (locator) {
+                const file = path.resolve(locator.split(LocatorSeparator)[0])
+                files.add(file)
+            }
+        }
+        return files
     }
 
     // TODO: Fix blocklist.json generated in nucleus so that the following works recursively instead of string


### PR DESCRIPTION
Need to ignore empty locator so as to skip resolving the file path.