### PR TITLE
Used generic cache removal instead of mocha dispose

### DIFF
--- a/packages/mocha-runner/src/mocha-runner.ts
+++ b/packages/mocha-runner/src/mocha-runner.ts
@@ -143,10 +143,8 @@ class MochaRunner implements TestRunner {
         try {
             mocha.dispose()
         }
-        catch(err)
-        {
+        catch(err) {
             // implies user is using mocha version < 7.2
-            console.warn("Using mocha < 7.2", err);
             // removing testfile from cache to reload testfiles when new mocha instance is created
             for (const testFile of testFilesToProcessList) {
                 delete require.cache[testFile];

--- a/packages/mocha-runner/src/mocha-runner.ts
+++ b/packages/mocha-runner/src/mocha-runner.ts
@@ -140,10 +140,18 @@ class MochaRunner implements TestRunner {
         // clearing blockTests and suites for next run
         this._blockTests = [];
         this._blockedSuites = [];
-        // removing testfile from cache to reload testfiles when new mocha instance is created
-        for (const testFile of testFilesToProcessList) {
-            delete require.cache[testFile];
-        } 
+        try {
+            mocha.dispose()
+        }
+        catch(err)
+        {
+            // implies user is using mocha version < 7.2
+            console.warn("Using mocha < 7.2", err);
+            // removing testfile from cache to reload testfiles when new mocha instance is created
+            for (const testFile of testFilesToProcessList) {
+                delete require.cache[testFile];
+            } 
+        }
         return results;
     }
 

--- a/packages/mocha-runner/src/mocha-runner.ts
+++ b/packages/mocha-runner/src/mocha-runner.ts
@@ -137,10 +137,13 @@ class MochaRunner implements TestRunner {
             results.testResults = Util.filterTestResultsByTestLocator(results.testResults,
                 this._testlocator, this._blockTestLocators);
         }
-        mocha.dispose();
         // clearing blockTests and suites for next run
         this._blockTests = [];
         this._blockedSuites = [];
+        // removing testfile from cache to reload testfiles when new mocha instance is created
+        for (const testFile of testFilesToProcessList) {
+            delete require.cache[testFile];
+        } 
         return results;
     }
 


### PR DESCRIPTION
# Issue

using  mocha dispose function for mocha version >=7.2
used  cached spec files  removal for mocha version < 7.2 to reload new spec

# Description

Removed mocha dispose function.
Instead of mocha dispose i removed cached spec files to reload new spec

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test standalone with latest version and 2.4.5 version
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules