### PR TITLE
Include user reporter

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -158,7 +158,6 @@ export class Util {
                 maxBodyLength: Infinity,
                 maxContentLength: Infinity
             });
-            console.log(data);
         } catch (err) {
             if (axios.isAxiosError(err)) {
                 const e = err as AxiosError;

--- a/packages/jasmine-runner/src/jasmine-reporter.ts
+++ b/packages/jasmine-runner/src/jasmine-reporter.ts
@@ -129,9 +129,8 @@ export class CustomReporter implements jasmine.CustomReporter {
         this.executionResults.testResults.push(test);
     }
 
-    jasmineDone(doneInfo: jasmine.JasmineDoneInfo): void {
+    jasmineDone(): void {
         const CODE_COVERAGE_DIR = process.env.CODE_COVERAGE_DIR as string;
-        console.log(doneInfo);
         if (CODE_COVERAGE_DIR) {
             for (const [filename, coverage] of this._coverageMap) {
                 const coverageFileName = `${CODE_COVERAGE_DIR}/${filename.replace(/\//g, '')}/coverage-final.json`;

--- a/packages/jasmine-runner/src/jasmine-runner.ts
+++ b/packages/jasmine-runner/src/jasmine-runner.ts
@@ -320,7 +320,7 @@ class JasmineRunner implements TestRunner {
         }
     }
 
-    private async jasmineExecute(jasmineObj: Jasmine, specIdsToRun: number[]) {
+    private async jasmineExecute(jasmineObj: Jasmine, specIdsToRun: number[]): Promise<void> {
         try {
             jasmineObj.loadHelpers();
             if (!jasmineObj.defaultReporterConfigured) {
@@ -329,7 +329,7 @@ class JasmineRunner implements TestRunner {
         } catch (err) {
             console.error(err);
         }
-        jasmineObj.env.execute(specIdsToRun as unknown as jasmine.Suite[]);
+        return jasmineObj.env.execute(specIdsToRun as unknown as jasmine.Suite[]);
     }
 }
 

--- a/packages/jasmine-runner/src/jasmine-runner.ts
+++ b/packages/jasmine-runner/src/jasmine-runner.ts
@@ -104,8 +104,8 @@ class JasmineRunner implements TestRunner {
                 specIdsToRun.push(-1);
             }
             const reporter = new CustomReporter(runTask, entityIdFilenameMap);
-            jasmine.getEnv().addReporter(reporter);
-            await jasmine.getEnv().execute(specIdsToRun as unknown as jasmine.Suite[]);
+            jasmineObj.addReporter(reporter);
+            await this.jasmineExecute(jasmineObj, specIdsToRun);
             const executionResult = await runTask.promise;
             Util.handleDuplicateTests(executionResult.testResults);
             if (locators.length > 0) {
@@ -187,7 +187,6 @@ class JasmineRunner implements TestRunner {
             await jasmineObj.loadHelpers();
         }
 
-        jasmineObj.env.clearReporters();
         jasmineObj.randomizeTests(false);
         return jasmineObj;
     }
@@ -319,6 +318,18 @@ class JasmineRunner implements TestRunner {
 
             }
         }
+    }
+
+    private async jasmineExecute(jasmineObj: Jasmine, specIdsToRun: number[]) {
+        try {
+            jasmineObj.loadHelpers();
+            if (!jasmineObj.defaultReporterConfigured) {
+                jasmineObj.configureDefaultReporter({ showColors: jasmineObj.showingColors });
+            }
+        } catch (err) {
+            console.error(err);
+        }
+        jasmineObj.env.execute(specIdsToRun as unknown as jasmine.Suite[]);
     }
 }
 

--- a/packages/jasmine-runner/src/jasmine-runner.ts
+++ b/packages/jasmine-runner/src/jasmine-runner.ts
@@ -355,6 +355,5 @@ class JasmineRunner implements TestRunner {
         console.error(e.stack);
         process.exit(-1);
     }
-    console.log("done");
     process.exit(0);
 })();

--- a/packages/jest-runner/src/jest-runner.ts
+++ b/packages/jest-runner/src/jest-runner.ts
@@ -298,6 +298,5 @@ class JestRunner implements TestRunner {
         console.error(e.stack);
         process.exit(-1);
     }
-    console.log("done");
     process.exit(0);
 })();

--- a/packages/jest-runner/src/jest-runner.ts
+++ b/packages/jest-runner/src/jest-runner.ts
@@ -197,16 +197,20 @@ class JestRunner implements TestRunner {
             useStderr: true,
             silent: true,
             config: argv.config,
-            reporters: reporters,
             collectCoverage: inExecutionPhase && !!process.env.TAS_COLLECT_COVERAGE
         };
         if (inExecutionPhase) {
+            const { globalConfig, configs } = await readConfigs(jestArgv, projectRoots);
             if (semver.lt(getVersion(), "24.0.0")) {
                 jestArgv.setupTestFrameworkScriptFile = SETUP_AFTER_ENV_FILE;
             } else {
-                const { configs } = await readConfigs(jestArgv, projectRoots);
                 const config = configs[0];
                 jestArgv.setupFilesAfterEnv = [SETUP_AFTER_ENV_FILE].concat(config.setupFilesAfterEnv);
+            }
+            if (globalConfig.reporters === undefined) {
+                jestArgv.reporters = reporters.concat(["default"]);
+            } else {
+                jestArgv.reporters = reporters.concat(globalConfig.reporters as string[]);
             }
         }
         await runCLI(jestArgv, projectRoots);

--- a/packages/mocha-runner/src/mocha-reporter.ts
+++ b/packages/mocha-runner/src/mocha-reporter.ts
@@ -32,8 +32,7 @@ const {
     STATE_STOPPED: 'stopped'
 };
 
-export class MochaReporter extends Mocha.reporters.Base {
-    private static RUNNER_ERROR = "Mocha Runner Error";
+class MochaReporter extends Mocha.reporters.Base {
 
     private _testResults: TestResult[] = [];
     private _suiteResults: TestSuiteResult[] = [];

--- a/packages/mocha-runner/src/mocha-reporter.ts
+++ b/packages/mocha-runner/src/mocha-reporter.ts
@@ -47,73 +47,49 @@ export class MochaReporter extends Mocha.reporters.Base {
         this.hookUsersReporter(runner, options);
 
         runner.on(EVENT_SUITE_BEGIN, () => {
-            try {
-                this._suiteStartTime = new Date();
-            } catch (err) {
-                console.error(MochaReporter.RUNNER_ERROR, err);
-            }
+            this._suiteStartTime = new Date();
         });
 
         runner.on(EVENT_SUITE_END, (suite: Mocha.Suite) => {
-            try {
-                if (!suite.root) {
-                    const underlyingTestStates: string[] = [];
-                    suite.eachTest((test) => {
-                        underlyingTestStates.push(test.state as string);
-                    });
-                    let suiteState = TestStatus.Passed;
-                    if (underlyingTestStates.find((item) => item === TestStatus.Failed)) {
-                        suiteState = TestStatus.Failed;
-                    }
-                    this._suiteResults.push(
-                        MochaHelper.transformMochaSuiteAsSuiteResult(suite, this._suiteStartTime, suiteState));
+            if (!suite.root) {
+                const underlyingTestStates: string[] = [];
+                suite.eachTest((test) => {
+                    underlyingTestStates.push(test.state as string);
+                });
+                let suiteState = TestStatus.Passed;
+                if (underlyingTestStates.find((item) => item === TestStatus.Failed)) {
+                    suiteState = TestStatus.Failed;
                 }
-                if (suite.file && global.__coverage__) {
-                    this._coverageMap.set(suite.file, global.__coverage__);
-                }
-            } catch (err) {
-                console.error(MochaReporter.RUNNER_ERROR, err);
+                this._suiteResults.push(
+                    MochaHelper.transformMochaSuiteAsSuiteResult(suite, this._suiteStartTime, suiteState));
+            }
+            if (suite.file && global.__coverage__) {
+                this._coverageMap.set(suite.file, global.__coverage__);
             }
         });
 
         runner.on(EVENT_TEST_BEGIN, () => {
-            try {
-                this._specStartTime = new Date();
-            } catch (err) {
-                console.error(MochaReporter.RUNNER_ERROR, err);
-            }
+            this._specStartTime = new Date();
         });
 
         runner.on(EVENT_TEST_PASS, (test: Mocha.Test) => {
-            try {
-                this._testResults.push(
-                    MochaHelper.transformMochaTestAsTestResult(test, this._specStartTime, TestStatus.Passed));
-            } catch (err) {
-                console.error(MochaReporter.RUNNER_ERROR, err);
-            }
+            this._testResults.push(
+                MochaHelper.transformMochaTestAsTestResult(test, this._specStartTime, TestStatus.Passed));
         });
 
         /**
          * Event emitted when a test doesn't define a body or it is marked as skipped ie it.skip()
          */
         runner.on(EVENT_TEST_PENDING, (test: Mocha.Test) => {
-            try {
-                this._testResults.push(
-                    MochaHelper.transformMochaTestAsTestResult(test, this._specStartTime, TestStatus.Skipped));
-            } catch (err) {
-                console.error(MochaReporter.RUNNER_ERROR, err);
-            }
+            this._testResults.push(
+                MochaHelper.transformMochaTestAsTestResult(test, this._specStartTime, TestStatus.Skipped));
         });
 
         runner.on(EVENT_TEST_FAIL, (test: Mocha.Test, err: Error) => {
-            try {
-                const failureMessage = (err.message || err.stack) ?? 'unknown error';
+            const failureMessage = (err.message || err.stack) ?? 'unknown error';
                 this._testResults.push(
                     MochaHelper.transformMochaTestAsTestResult(test, this._specStartTime, 
                         TestStatus.Failed, failureMessage));
-            } catch (err) {
-                console.error(MochaReporter.RUNNER_ERROR, err);
-            }
         });
 
         runner.once(EVENT_RUN_END, () => {

--- a/packages/mocha-runner/src/mocha-runner.ts
+++ b/packages/mocha-runner/src/mocha-runner.ts
@@ -121,8 +121,7 @@ class MochaRunner implements TestRunner {
         for (const filename of testFilesToProcessList) {
             mocha.addFile(filename);
         }
-        const runnerWithResults: CustomRunner = mocha.run((failures: number) => {
-            console.error("# of failed tests:", failures);
+        const runnerWithResults: CustomRunner = mocha.run(() => {
             testRunTask.resolve();
         });
         await testRunTask.promise;
@@ -340,7 +339,7 @@ class MochaRunner implements TestRunner {
             return opts;
         } catch (err) {
             // implies user is using mocha version < 6
-            console.warn("Using mocha < 6", err);
+            console.info("Using mocha < 6");
             const optsFilePath = argv.config ?? "./test/mocha.opts";
             if (fs.existsSync(optsFilePath)) {
                 // Following code translates newlines separated mocha opts file
@@ -376,7 +375,6 @@ class MochaRunner implements TestRunner {
         console.error(e.stack);
         process.exit(-1);
     }
-    console.log("done");
     process.exit(0);
 })();
 


### PR DESCRIPTION
# Issue

https://github.com/LambdaTest/test-at-scale-js/issues/14

# Description

- Adds custom reporters on top of user-defined/used reporters in all 3 runners.
- Removed noisy console logs

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

This has been tested manually on:
- `jasmine` framework: `angular.js` and `jasmine-reporters` repos.
- `mocha` framework: `express` repo by tweaking the reporters in `.mocharc.json` to `spec`, `tap`, `dot` and undefined.
- `jest` framework: `rheostat` repository.

For all 3 frameworks, I had verified that the output in console by running tests locally (using scripts like `npm run test`) and the output emitted by custom runner is the same.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules