### PR TITLE
Fix duration blocklisted tests

### DIFF
--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -120,7 +120,6 @@ export class DiscoveryResult {
     orgID: ID;
     branch: string;
     executeAllTests: boolean;
-    parallelism: number;
     constructor(tests: Test[],
         testSuites: TestSuite[],
         impactedTests: ID[],
@@ -130,8 +129,7 @@ export class DiscoveryResult {
         taskID: ID,
         orgID: ID,
         branch: string,
-        executeAllTests?: boolean,
-        parallelism?: number) {
+        executeAllTests?: boolean) {
         this.tests = tests;
         this.testSuites = testSuites;
         this.repoID = repoID;
@@ -142,7 +140,6 @@ export class DiscoveryResult {
         this.branch = branch
         this.impactedTests = impactedTests
         this.executeAllTests = executeAllTests ? executeAllTests : false;
-        this.parallelism = parallelism ? parallelism : 0;
     }
 }
 

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -38,6 +38,8 @@ export class Util {
     private static blockTestMap: { [key: string]: { source: string, locator: string, status: string }[]; } = {};
     private static blockTestMapInitialized = false;
 
+    static noOp = (): void => { return };
+    
     static getIdentifier(fileName: string, testName: string): string {
         const relFilePath = path.relative(this.REPO_ROOT, fileName);
         return testName + ' (' + relFilePath + ')';

--- a/packages/jasmine-runner/package.json
+++ b/packages/jasmine-runner/package.json
@@ -27,6 +27,6 @@
   },
   "peerDependencies": {
     "@types/jasmine": "^3.8.2",
-    "jasmine": "^2.4.1"
+    "jasmine": ">=2.1.0"
   }
 }

--- a/packages/jasmine-runner/src/jasmine-reporter.ts
+++ b/packages/jasmine-runner/src/jasmine-reporter.ts
@@ -103,7 +103,10 @@ export class CustomReporter implements jasmine.CustomReporter {
         if (result.status === TestStatus.Failed) {
             failureMessage = result.failedExpectations.map((failedExpectation) => failedExpectation.message).join(', ')
         }
-        const duration: number = result.duration ?? ((new Date()).getTime() - this.specStartTime.getTime())
+        let duration = 0;
+        if (result.status === TestStatus.Passed || result.status === TestStatus.Failed) {
+            duration = result.duration ?? ((new Date()).getTime() - this.specStartTime.getTime());
+        }
         const test = new TestResult(
             crypto
                 .createHash("md5")

--- a/packages/jasmine-runner/src/jasmine-runner.ts
+++ b/packages/jasmine-runner/src/jasmine-runner.ts
@@ -32,7 +32,6 @@ class JasmineRunner implements TestRunner {
 
         Validations.validateDiscoveryEnv(argv);
         const repoID = process.env.REPO_ID as ID;
-        const parallelism = isNaN(Number(process.env.TAS_PARALLELISM)) ? 0 : Number(process.env.TAS_PARALLELISM);
         const orgID = process.env.ORG_ID as ID;
         const buildID = process.env.BUILD_ID as ID;
         const taskID = process.env.TASK_ID as ID;
@@ -54,7 +53,7 @@ class JasmineRunner implements TestRunner {
             const [impactedTests, executeAllTests] = await Util.findImpactedTests(testsDepsMap, tests, changedFilesSet);
 
             const result = new DiscoveryResult(tests, testSuites, impactedTests,
-                repoID, commitID, buildID, taskID, orgID, branch, executeAllTests, parallelism);
+                repoID, commitID, buildID, taskID, orgID, branch, executeAllTests);
             Util.fillTotalTests(result);
             if (postTestListEndpoint) {
                 await Util.makeApiRequestPost(postTestListEndpoint, result);
@@ -187,7 +186,11 @@ class JasmineRunner implements TestRunner {
             await jasmineObj.loadHelpers();
         }
 
-        jasmineObj.randomizeTests(false);
+        try {
+            jasmineObj.randomizeTests(false);
+        } catch (err) {
+            Util.noOp();
+        }
         return jasmineObj;
     }
 
@@ -327,7 +330,7 @@ class JasmineRunner implements TestRunner {
                 jasmineObj.configureDefaultReporter({ showColors: jasmineObj.showingColors });
             }
         } catch (err) {
-            console.error(err);
+            Util.noOp();
         }
         return jasmineObj.env.execute(specIdsToRun as unknown as jasmine.Suite[]);
     }

--- a/packages/jest-runner/src/jest-runner.ts
+++ b/packages/jest-runner/src/jest-runner.ts
@@ -55,7 +55,6 @@ class JestRunner implements TestRunner {
         const taskID = process.env.TASK_ID as ID;
         const orgID = process.env.ORG_ID as ID;
         const commitID = process.env.COMMIT_ID as ID;
-        const parallelism = isNaN(Number(process.env.TAS_PARALLELISM)) ? 0 : Number(process.env.TAS_PARALLELISM);
         const postTestListEndpoint = process.env.ENDPOINT_POST_TEST_LIST as string || "";
         const branch = process.env.BRANCH_NAME as string;
         const cleanup = (argv.cleanup as boolean) ? argv.cleanup : true;
@@ -86,7 +85,7 @@ class JestRunner implements TestRunner {
         const discoveryResult = new DiscoveryResult(tests,
             testSuites,
             impactedTests,
-            repoID, commitID, buildID, taskID, orgID, branch, executeAllTests, parallelism);
+            repoID, commitID, buildID, taskID, orgID, branch, executeAllTests);
         if (cleanup) {
             await fs.promises.rm(TAS_DIRECTORY, { recursive: true });
         }

--- a/packages/mocha-runner/src/helper.ts
+++ b/packages/mocha-runner/src/helper.ts
@@ -31,7 +31,10 @@ export class MochaHelper {
         const testIdentifier = Util.getIdentifier(filename, test.title);
         const locator = Util.getLocator(filename, parentSuites, test.title);
         const blockTest = Util.getBlockTestLocatorProperties(locator);
-        const duration: number = test.duration ?? (new Date()).getTime() - specStartTime.getTime();
+        let duration = 0;
+        if (state === TestStatus.Passed || state === TestStatus.Failed) {
+            duration = test.duration ?? ((new Date()).getTime() - specStartTime.getTime());
+        }
         return new TestResult(
             crypto
                 .createHash("md5")

--- a/packages/mocha-runner/src/mocha-runner.ts
+++ b/packages/mocha-runner/src/mocha-runner.ts
@@ -60,7 +60,6 @@ class MochaRunner implements TestRunner {
         const taskID = process.env.TASK_ID as ID;
         const orgID = process.env.ORG_ID as ID;
         const commitID = process.env.COMMIT_ID as ID;
-        const parallelism = isNaN(Number(process.env.TAS_PARALLELISM)) ? 0 : Number(process.env.TAS_PARALLELISM);
         const postTestListEndpoint = process.env.ENDPOINT_POST_TEST_LIST as string || "";
         const branch = process.env.BRANCH_NAME as string;
         const testFilesGlob = argv.pattern as string | string[];
@@ -87,7 +86,7 @@ class MochaRunner implements TestRunner {
         const [impactedTests, executeAllTests] = await Util.findImpactedTests(testsDepsMap, tests, changedFilesSet);
 
         const result = new DiscoveryResult(tests, testSuites, impactedTests,
-            repoID, commitID, buildID, taskID, orgID, branch, executeAllTests, parallelism);
+            repoID, commitID, buildID, taskID, orgID, branch, executeAllTests);
         Util.fillTotalTests(result);
         if (postTestListEndpoint) {
             try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,9 +3583,9 @@ minimist-options@4.1.0:
     kind-of "^6.0.3"
 
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
# Issue

https://github.com/LambdaTest/test-at-scale-js/issues/20

# Description

- Removed unnecessary `parallelism` field in DiscoveryResult.
- Fixed unexecuted tests duration >0ms in mocha and jasmine runners

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This is tested locally on `jasmine-node-js-example` repository after blocklisting and un-blocklisting tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules