### PR TITLE
Dry-running tests in discovery fails snapshot resulting in non-zero exitCode

### DIFF
--- a/packages/jest-runner/src/jest-discover-reporter.ts
+++ b/packages/jest-runner/src/jest-discover-reporter.ts
@@ -22,6 +22,7 @@ class JestDiscoverReporter {
     private tests: TASTest[];
     private testSuites: Map<ID, TASTestSuite>;
     private testsDependenciesMap: TASTestsDependenciesMap | null;
+    private hasErrors = false;
 
     constructor(globalConfig: Config.GlobalConfig) {
         this._globalConfig = globalConfig
@@ -85,6 +86,7 @@ class JestDiscoverReporter {
         });
         
         if (testResult && testResult.failureMessage) {
+            this.hasErrors = true;
             process.stderr.write(testResult.failureMessage);
         }
     }
@@ -118,6 +120,13 @@ class JestDiscoverReporter {
             fs.createWriteStream(TESTS_DEPENDENCIES_MAP_FILE),
             JSONStream.replacer
         );
+
+        const code = !this.hasErrors ? 0 : this._globalConfig.testFailureExitCode;
+        process.on('exit', () => {
+            if (typeof code === 'number' && code !== 0) {
+                process.exitCode = code;
+            }
+        });
     }
 }
 

--- a/packages/jest-runner/src/jest-runner.ts
+++ b/packages/jest-runner/src/jest-runner.ts
@@ -213,13 +213,7 @@ class JestRunner implements TestRunner {
             jestArgv.reporters = reporters;
             jestArgv.silent = true;
         }
-        const {results, globalConfig} = await runCLI(jestArgv, projectRoots);
-        const code = !results || results.success ? 0 : globalConfig.testFailureExitCode; // Only exit if needed
-        process.on('exit', () => {
-            if (typeof code === 'number' && code !== 0) {
-                process.exitCode = code;
-            }
-        });
+        await runCLI(jestArgv, projectRoots);
     }
 
     private getBlockTestAndTestRegex(testFiles: string[], testLocators: Set<string>): [string, Set<string>] {


### PR DESCRIPTION
# Issue

https://github.com/LambdaTest/test-at-scale-js/issues/17

# Description

- Moved exitCode handling inside reporter.
- discovery now digests snapshot failures due to dry-run of tests

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is tested on `docusaurus` repository which exits with non-zero exit-code on dry running tests.
With this change, discovery is successful.
Without this change, discovery command exits with non-zero exitCode
Also, tested the scenarios of syntax errors. Working as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules