### PR TITLE
Bug Fix: In case of empty diff, 0 tests should be impacted

### DIFF
--- a/packages/jasmine-runner/src/jasmine-runner.ts
+++ b/packages/jasmine-runner/src/jasmine-runner.ts
@@ -39,18 +39,17 @@ class JasmineRunner implements TestRunner {
         const postTestListEndpoint = process.env.ENDPOINT_POST_TEST_LIST as string || "";
         const branch = process.env.BRANCH_NAME as string;
         const testFilesGlob = argv.pattern as string | string[];
-        const changedFiles = argv.diff as Array<string>;
-        const changedFilesSet = new Set(changedFiles);
+        const changedFilesSet = argv.diff === undefined ? undefined : new Set(argv.diff as string | string[]);
+
 
         try {
             const testFiles = glob.sync(testFilesGlob).map(file => path.resolve(file));
-            const testsDepsMap = await Util.listDependencies(testFiles);
             const jasmineObj = await this.createJasmineRunner(argv.config);
             await this.loadSpecs(jasmineObj, testFiles, entityIdFilenameMap);
             const rootSuite = jasmineObj.env.topSuite();
             this.listTestsAndTestSuites(rootSuite, tests, testSuites, entityIdFilenameMap);
             Util.handleDuplicateTests(tests);
-            const [impactedTests, executeAllTests] = await Util.findImpactedTests(testsDepsMap, tests, changedFilesSet);
+            const [impactedTests, executeAllTests] = await Util.findImpactedTests(tests, changedFilesSet, testFiles);
 
             const result = new DiscoveryResult(tests, testSuites, impactedTests,
                 repoID, commitID, buildID, taskID, orgID, branch, executeAllTests);

--- a/packages/jest-runner/src/jest-runner.ts
+++ b/packages/jest-runner/src/jest-runner.ts
@@ -61,9 +61,7 @@ class JestRunner implements TestRunner {
         if (testFiles.length === 0) {
             return new DiscoveryResult([], [], [], repoID, commitID, buildID, taskID, orgID, branch);
         }
-        const changedFiles = argv.diff as Array<string> | string[];
-        const changedFilesSet = new Set(changedFiles);
-        const testsDepsMap = await Util.listDependencies(testFiles);
+        const changedFilesSet = argv.diff === undefined ? undefined : new Set(argv.diff as string | string[]);
 
         await this.runJest(testFiles, MATCH_NOTHING_REGEX, [require.resolve("./jest-discover-reporter")]);
 
@@ -71,7 +69,7 @@ class JestRunner implements TestRunner {
         const tests: Test[] = (result.tests ?? []).map((test: any) => Test.fromJSON(test));
         const testSuites: TestSuite[] = (result.testSuites ?? []).map(TestSuite.fromJSON);
         Util.handleDuplicateTests(tests);
-        const [impactedTests, executeAllTests] = await Util.findImpactedTests(testsDepsMap, tests, changedFilesSet);
+        const [impactedTests, executeAllTests] = await Util.findImpactedTests(tests, changedFilesSet, testFiles);
 
         const discoveryResult = new DiscoveryResult(tests,
             testSuites,

--- a/packages/mocha-runner/src/mocha-runner.ts
+++ b/packages/mocha-runner/src/mocha-runner.ts
@@ -67,8 +67,7 @@ class MochaRunner implements TestRunner {
         if (testFiles.length === 0) {
             return new DiscoveryResult([], [], [], repoID, commitID, buildID, taskID, orgID, branch);
         }
-        const changedFiles = argv.diff as Array<string>;
-        const changedFilesSet = new Set(changedFiles);
+        const changedFilesSet = argv.diff === undefined ? undefined : new Set(argv.diff as string | string[]);
 
         for (const filename of testFiles) {
             mocha.addFile(filename);
@@ -79,11 +78,10 @@ class MochaRunner implements TestRunner {
             mocha['loadFiles']();
         }
 
-        const testsDepsMap = await Util.listDependencies(testFiles);
         // pass root suite
         this.listTestsAndTestSuites(mocha.suite, tests, testSuites);
         Util.handleDuplicateTests(tests);
-        const [impactedTests, executeAllTests] = await Util.findImpactedTests(testsDepsMap, tests, changedFilesSet);
+        const [impactedTests, executeAllTests] = await Util.findImpactedTests(tests, changedFilesSet, testFiles);
 
         const result = new DiscoveryResult(tests, testSuites, impactedTests,
             repoID, commitID, buildID, taskID, orgID, branch, executeAllTests);


### PR DESCRIPTION
# Description

- In case of empty diff, run no tests.
- refactored listingDependencies to avoid duplicacy

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally with
- `--diff` - impacted 0 tests. Earlier, it was impacting all tests.
- `--diff abc.js` - working as expected
- `--diff abc.js --diff bcd.js` - working as expected
- without `--diff` - impacted all tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules