### PR TITLE
#42: Added support of relative requires in mocha-runner. Added support of shorthand options of mocha.opts

### DIFF
--- a/packages/mocha-runner/src/helper.ts
+++ b/packages/mocha-runner/src/helper.ts
@@ -1,6 +1,31 @@
 import Mocha from "mocha";
+import fs from "fs";
 import crypto from "crypto";
+import parser from "yargs-parser";
 import { ID, TestResult, TASDate as Date, TestStatus, TestSuiteResult, Util } from "@lambdatest/test-at-scale-core";
+
+const shortHandOptsMap = new Map<string, string>(
+    [
+        ["-A", "--async-only"],
+        ["-c", "--colors"],
+        ["-C", "--no-colors"],
+        ["-G", "--growl"],
+        ["-O", "--reporter-options"],
+        ["-R", "--reporter"],
+        ["-S", "--sort"],
+        ["-b", "--bail"],
+        ["-d", "--debug"],
+        ["-g", "--grep"],
+        ["-f", "--fgrep"],
+        ["-gc", "--expose-gc"],
+        ["-i", "--invert"],
+        ["-r", "--require"],
+        ["-s", "--slow"],
+        ["-t", "--timeout"],
+        ["-u", "--ui"],
+        ["-w", "--watch"]
+    ]
+);
 
 export class MochaHelper {
 
@@ -92,6 +117,38 @@ export class MochaHelper {
             blocktest.source,
             suiteStartTime
         );
+    }
+
+    static getFilteredConfigs(argv: parser.Arguments): Mocha.MochaOptions {
+        const args = [];
+        if (argv.config !== undefined) {
+            args.push("--config", argv.config);
+        }
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const loadOptions = require('mocha/lib/cli/options').loadOptions;
+            const opts = loadOptions(args) as Mocha.MochaOptions;
+            opts.parallel = false;
+            return opts;
+        } catch (err) {
+            // implies user is using mocha version < 6
+            console.warn("Using mocha < 6");
+            const optsFilePath = argv.config ?? "./test/mocha.opts";
+            if (fs.existsSync(optsFilePath)) {
+                // Following code translates newlines separated mocha opts file
+                // to space separated command-line opts string
+                const opts = fs
+                    .readFileSync(optsFilePath, 'utf8')
+                    .replace(/^#.*$/gm, '')
+                    .replace(/\\\s/g, '%20')
+                    .split(/\s/)
+                    .filter(Boolean)
+                    .map(value => value.replace(/%20/g, ' '))
+                    .map(value => shortHandOptsMap.get(value) ?? value);
+                return parser(opts) as Mocha.MochaOptions;
+            }
+            return {};
+        }
     }
 }
 

--- a/packages/mocha-runner/src/helper.ts
+++ b/packages/mocha-runner/src/helper.ts
@@ -135,8 +135,7 @@ export class MochaHelper {
             console.warn("Using mocha < 6");
             const optsFilePath = argv.config ?? "./test/mocha.opts";
             if (fs.existsSync(optsFilePath)) {
-                // Following code translates newlines separated mocha opts file
-                // to space separated command-line opts string
+                // Following code translates mocha opts file to longhand opts array
                 const opts = fs
                     .readFileSync(optsFilePath, 'utf8')
                     .replace(/^#.*$/gm, '')


### PR DESCRIPTION
# Issue

#42 

# Description

- Fixed relative requires in mocha runner.
- Added shorthand options in mocha < 6

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on superstruct repo by providing both kinds of paths for `require`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules