### PR TITLE
Fixed jest-config import issue

### DIFF
--- a/packages/jest-runner/src/jest-runner.ts
+++ b/packages/jest-runner/src/jest-runner.ts
@@ -8,7 +8,6 @@ import parser from "yargs-parser";
 import semver from "semver";
 import type { Config } from '@jest/types';
 import { runCLI, getVersion } from "jest";
-import { readConfig } from "jest-config";
 import { hideBin } from "yargs/helpers";
 import {
     DiscoveryResult,
@@ -159,6 +158,9 @@ class JestRunner implements TestRunner {
             cacheDirectory: JEST_CACHE_DIR
         };
         if (inExecutionPhase) {
+            // jest-config is guaranteed to be present in jest-cli's node_modules if not outside
+            module.paths.push(path.join(require.resolve("jest-cli"), "node_modules"));
+            const { readConfig } = await import("jest-config");
             const { globalConfig, projectConfig } = await readConfig(jestArgv, Util.REPO_ROOT);
             if (semver.lt(getVersion(), "24.0.0")) {
                 jestArgv.setupTestFrameworkScriptFile = SETUP_AFTER_ENV_FILE;


### PR DESCRIPTION
# Description

For some repositories like [snyk/cli](https://github.com/snyk/cli), runner errors out with `module not found 'jest-config'`. I see that we're importing `jest-config` which may not always be present in project's root `node_modules`. It will definitely be present in node_modules of `jest-cli` package if not present in root node_modules. Hence, this diff adds jest-cli's node_modules path as a fallback module resolution path to require-resolve `jest-config`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested locally on snyk/cli repository.
Without this diff, discovery failed.
With this diff, discovery succeeded. Checked execution as well, it also succeeded.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules