### PR TITLE
Spawning docker aware jest workers

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
@@ -369,5 +370,22 @@ export class Util {
             this.smartSelectAvailable = true;
         }
         return this.smartSelectAvailable;
+    }
+
+    static getCpus(): number {
+        function readNumber(file: string) {
+            return Number(fs.readFileSync(file, "utf-8"));
+        }
+        let maybeResult = -1;
+        try {
+            maybeResult = (readNumber("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") /
+                readNumber("/sys/fs/cgroup/cpu/cpu.cfs_period_us"));
+        } catch (err) {
+            this.noOp()
+        }
+        if (maybeResult > 0) {
+            return maybeResult;
+        }
+        return os.cpus().length;
     }
 }

--- a/packages/jest-runner/src/jest-runner.ts
+++ b/packages/jest-runner/src/jest-runner.ts
@@ -176,6 +176,7 @@ class JestRunner implements TestRunner {
             jestArgv.runInBand = true;
         } else {
             jestArgv.silent = true;
+            jestArgv.maxWorkers = Util.getCpus() - 1;
         }
         jestArgv.reporters = reporters as unknown as string[];
         await runCLI(jestArgv, [Util.REPO_ROOT]);


### PR DESCRIPTION
# Issue

In a containerised environment like docker, the default number of jest-workers reads the `os.cpus().length` which reads the cpus of the underlying host and not the cpu-share that the container has actually received. Therefore, we'll see heavy cpu throttling in such cases.

# Description

This diff aims to use the files on the basis of which cpu-shares is defined to find out the correct number of jest workers to spawn for discovery process.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the logic independently in a nodejs docker k8s pod with cpu-requests as 1500m and cpu-limits as 3500m. This method correctly outputed `3.5` instead of 4.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules