### PR TITLE
fix: correct double brand-name substitution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 ## Getting Started
 
-TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) is an AI-native, multi-agent quality engineering platform that enables teams to plan, author, execute, analyze, and optimize tests at scale across browsers, devices, and frameworks.
+TestMu AI (Formerly LambdaTest) is an AI-native, multi-agent quality engineering platform that enables teams to plan, author, execute, analyze, and optimize tests at scale across browsers, devices, and frameworks.
 
-Custom runners written on top of JavaScript testing frameworks for running test-at-scale on TestMu AI (Formerly TestMu AI (Formerly LambdaTest)). This runner supports Mocha, Jest and Jasmine.
+Custom runners written on top of JavaScript testing frameworks for running test-at-scale on TestMu AI (Formerly LambdaTest). This runner supports Mocha, Jest and Jasmine.
 
-- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly TestMu AI (Formerly LambdaTest)).
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
 # test-at-scale-js
@@ -67,17 +67,17 @@ RUN npm i --global-style --legacy-peer-deps lambdatest-1.0.0.tgz
 
 This project is used by:
 
-- TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) TAS
+- TestMu AI (Formerly LambdaTest) TAS
 
-## TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) Community
+## TestMu AI (Formerly LambdaTest) Community
 
 Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
 
-## TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) Certifications
+## TestMu AI (Formerly LambdaTest) Certifications
 
 Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-## Learning Resources by TestMu AI (Formerly TestMu AI (Formerly LambdaTest))
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
 Learn modern testing through tutorials, guides, videos, and weekly updates:
 


### PR DESCRIPTION
Fix double-substituted "TestMu AI (Formerly TestMu AI (Formerly LambdaTest))" → "TestMu AI (Formerly LambdaTest)". Remove extra non-template badges.